### PR TITLE
refactor HTTP request message parser

### DIFF
--- a/includes/HttpRequest.hpp
+++ b/includes/HttpRequest.hpp
@@ -47,6 +47,16 @@ class HttpRequest {
   static std::string::size_type FindEndOfHeader(const std::string& payload);
   const char* ParseHeader(const char* req);
   bool IsCRLF(const char* p) const;
+
+  bool ValidateAndSkipCRLF(size_t& pos) {
+    if (pos + 1 >= buffer_.size()) return false;
+    if (buffer_[pos] != '\r' || buffer_[pos + 1] != '\n') {
+      throw lib::exception::ResponseStatusException(lib::http::kBadRequest);
+    }
+    pos += 2;
+    return true;
+  }
+
   void BumpLenOrThrow(size_t& total, size_t inc) const;
   const char* ReadHeaderLine(const char* req, std::string& key,
                              std::string& value, size_t& total_len);

--- a/includes/host_validation.hpp
+++ b/includes/host_validation.hpp
@@ -23,7 +23,8 @@ inline bool ContainsInvalidChars(const std::string& host) {
 bool LooksLikeIPv4(const std::string& host);
 bool IsValidIPv4Segment(const std::string& segment);
 bool IsValidIPv4(const std::string& host);
-bool LooksLikeDomain(const std::string& host);
+bool IsValidDomainLabel(const std::string& label);
+bool IsValidDomainName(const std::string& host);
 bool IsValidHost(const std::string& host);
 
 }  // namespace host_validation

--- a/srcs/http_request/HttpRequest_consumeHeader.cpp
+++ b/srcs/http_request/HttpRequest_consumeHeader.cpp
@@ -37,7 +37,7 @@ const char* HttpRequest::ReadHeaderLine(const char* req, std::string& key,
     throw lib::exception::ResponseStatusException(lib::http::kBadRequest);
   }
   key.assign(req, i);
-  // ": " を飛ばす
+  // skip": "
   i += 2;
   BumpLenOrThrow(total_len, 2);
   req += i;


### PR DESCRIPTION
**HTTP Request Parsing Improvements:**

* Introduced a new method `ValidateAndSkipCRLF` in `HttpRequest` to centralize and standardize CRLF validation and skipping logic, replacing duplicated code in chunked transfer decoding and final CRLF checks. 
* Updated the logic in `ParseChunkSize`, `AppendChunkData`, and `ValidateFinalCRLF` to use the new CRLF validation method
* Changed buffer clearing after the final CRLF to use `buffer_.clear()` for clarity and correctness. 

**Host Validation Enhancements:**

* Replaced the ambiguous `LooksLikeDomain` function with stricter `IsValidDomainLabel` and `IsValidDomainName` functions for domain validation, ensuring compliance with DNS rules (e.g., no leading/trailing hyphens, valid label lengths, at least two labels). 