### PR TITLE
implement redirect with 302

### DIFF
--- a/includes/ConfigParser.hpp
+++ b/includes/ConfigParser.hpp
@@ -26,7 +26,7 @@ const std::string kAutoIndex = "autoindex";
 const std::string kIndex = "index";
 const std::string kUploadPath = "upload_path";
 const std::string kServer = "server";
-const std::string kRedirect = "return";
+const std::string kRedirect = "redirect";
 const std::string kCgi = "cgi";
 const std::string kCgiAllowedExtensions = "cgi_allowed_extensions";
 }  // namespace config_tokens

--- a/includes/Location.hpp
+++ b/includes/Location.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "lib/http/Method.hpp"
+#include "lib/http/Status.hpp"
 
 class Location {
  private:
@@ -18,6 +19,7 @@ class Location {
   std::string index_file_;
   std::string upload_path_;
   std::string redirect_;
+  lib::http::Status redirect_status_;
   bool cgi_enabled_;
   std::vector<std::string> cgi_allowed_extensions_;
   bool has_allowed_methods_;  // method directive should appear only once
@@ -129,11 +131,20 @@ class Location {
       throw std::runtime_error("Duplicate redirect directive");
     }
     redirect_ = redirect;
+    redirect_status_ = lib::http::kFound;
     has_redirect_ = true;
   }
 
   const std::string& GetRedirect() const {
     return redirect_;
+  }
+
+  lib::http::Status GetRedirectStatus() const {
+    return redirect_status_;
+  }
+
+  bool HasRedirect() const {
+    return has_redirect_;
   }
 
   void SetCgiEnabled(const std::string& value) {

--- a/sample_config/server_redirect.conf
+++ b/sample_config/server_redirect.conf
@@ -1,0 +1,17 @@
+server {
+    listen 8080;
+    server_name redirect.example.com;
+
+    location /old/ {
+        redirect /new/;
+    }
+
+    location /google/ {
+        redirect https://www.google.com;
+    }
+
+    location /new/ {
+        root /var/www/html/site_8080/data;
+        index welcome.html;
+    }
+}

--- a/srcs/lib/http/Status.cpp
+++ b/srcs/lib/http/Status.cpp
@@ -15,6 +15,8 @@ std::string StatusToString(Status status) {
       return "No Content";
     case kResetContent:
       return "Reset Content";
+    case kFound:
+      return "Found";
     case kTemporaryRedirect:
       return "Temporary Redirect";
     case lib::http::kBadRequest:

--- a/srcs/location.cpp
+++ b/srcs/location.cpp
@@ -8,6 +8,7 @@ Location::Location()
       index_file_(),
       upload_path_(),
       redirect_(),
+      redirect_status_(lib::http::kFound),
       cgi_enabled_(false),
       cgi_allowed_extensions_(),
       has_allowed_methods_(false),

--- a/tests/config_parser/config_parseLocation.test.cpp
+++ b/tests/config_parser/config_parseLocation.test.cpp
@@ -76,6 +76,21 @@ TEST(ConfigParser, Location_WithSeveralKnownDirectives) {
   EXPECT_EQ(locs[0].GetName(), "/app/");
 }
 
+TEST(ConfigParser, Location_WithRedirect) {
+  ServerConfig sc;
+  const std::string s =
+      "/old/ {\n"
+      "  redirect /new/page.html;\n"
+      "}\n";
+  EXPECT_NO_THROW(callParseLocation(s, &sc));
+
+  const std::vector<Location>& locs = sc.GetLocations();
+  ASSERT_EQ(locs.size(), 1u);
+  EXPECT_TRUE(locs[0].HasRedirect());
+  EXPECT_EQ(locs[0].GetRedirect(), "/new/page.html");
+  EXPECT_EQ(locs[0].GetRedirectStatus(), lib::http::kFound);
+}
+
 // ==================== error cases ====================
 
 TEST(ConfigParser, Location_InvalidName_NoLeadingSlash_Throws) {


### PR DESCRIPTION
sample_config/server_redirect.conf に書いたスタイルでの redirection を設定する
status は 302 Found 固定です。

動作確認
```bash
make
./webserv sample_config/server_redirect.conf
```

- ブラウザで、`localhost:8080/old/welcome.html` に接続すると `localhost:8080/new/welcome.html` にリダイレクトされる
- ブラウザで、`localhost:8080/google` に接続すると `google.com` にリダイレクトされる