### PR TITLE
add build error page

### DIFF
--- a/includes/RequestHandler.hpp
+++ b/includes/RequestHandler.hpp
@@ -64,6 +64,7 @@ class RequestHandler {
   void HandleDelete();
   std::string GenerateDirectoryListing(const std::string &path,
                                        const std::string &req_uri) const;
+  HttpResponse BuildErrorResponse(lib::http::Status status);
 };
 
 #endif

--- a/includes/ServerConfig.hpp
+++ b/includes/ServerConfig.hpp
@@ -64,16 +64,17 @@ class ServerConfig {
     return errors_;
   }
 
-  std::string GetErrorPagesString() const {
-    std::string result;
-    for (std::map<lib::http::Status, std::string>::const_iterator it =
-             errors_.begin();
-         it != errors_.end(); ++it) {
-      std::ostringstream oss;
-      oss << it->first;
-      result += "    " + oss.str() + " -> " + it->second + "\n";
+  bool HasErrorPage(lib::http::Status status) const {
+    return errors_.find(status) != errors_.end();
+  }
+
+  const std::string& GetErrorPage(lib::http::Status status) const {
+    std::map<lib::http::Status, std::string>::const_iterator it =
+        errors_.find(status);
+    if (it == errors_.end()) {
+      throw std::runtime_error("Error page not found");
     }
-    return result;
+    return it->second;
   }
 
   /*

--- a/includes/ServerConfig.hpp
+++ b/includes/ServerConfig.hpp
@@ -16,6 +16,7 @@
 #include "LocationMatch.hpp"
 #include "lib/exception/ResponseStatusException.hpp"
 #include "lib/http/Status.hpp"
+#include "lib/type/Optional.hpp"
 
 class ServerConfig {
  private:

--- a/includes/ServerConfig.hpp
+++ b/includes/ServerConfig.hpp
@@ -68,13 +68,14 @@ class ServerConfig {
     return errors_.find(status) != errors_.end();
   }
 
-  const std::string& GetErrorPage(lib::http::Status status) const {
+  lib::type::Optional<std::string> GetErrorPage(
+      lib::http::Status status) const {
     std::map<lib::http::Status, std::string>::const_iterator it =
         errors_.find(status);
     if (it == errors_.end()) {
-      throw std::runtime_error("Error page not found");
+      return lib::type::Optional<std::string>();
     }
-    return it->second;
+    return lib::type::Optional<std::string>(it->second);
   }
 
   /*

--- a/srcs/RequestHandler.cpp
+++ b/srcs/RequestHandler.cpp
@@ -33,12 +33,8 @@ ExecResult RequestHandler::Run() {
     lib::http::Method method = req_.GetMethod();
     if (location_match_.loc->HasAllowedMethods()) {
       if (!location_match_.loc->IsMethodAllowed(method)) {
-        HttpResponse res;
-        res.SetStatus(lib::http::kMethodNotAllowed);  // 405
+        HttpResponse res = BuildErrorResponse(lib::http::kMethodNotAllowed);
         res.AddHeader("Allow", location_match_.loc->GetAllowedMethodsString());
-        res.AddHeader("Connection", "close");
-        res.AddHeader("Content-Type", "text/html");
-        res.EnsureDefaultErrorContent();
         return ExecResult(res);
       }
     }
@@ -54,13 +50,9 @@ ExecResult RequestHandler::Run() {
     }
     return result_;
   } catch (const lib::exception::ResponseStatusException& e) {
-    HttpResponse res(e.GetStatus());
-    res.SetBody(lib::http::StatusToString(e.GetStatus()));
-    return ExecResult(res);
+    return ExecResult(BuildErrorResponse(e.GetStatus()));
   } catch (const std::exception& e) {
-    HttpResponse res(lib::http::kInternalServerError);
-    res.SetBody("Internal Server Error");
-    return ExecResult(res);
+    return ExecResult(BuildErrorResponse(lib::http::kInternalServerError));
   }
 }
 
@@ -367,4 +359,52 @@ std::string RequestHandler::GenerateDirectoryListing(
        << "</html>";
 
   return html.str();
+}
+
+HttpResponse RequestHandler::BuildErrorResponse(lib::http::Status status) {
+  HttpResponse res(status);
+  res.AddHeader("Content-Type", "text/html");
+  res.AddHeader("Connection", "close");
+
+  try {
+    if (conf_.HasErrorPage(status)) {
+      const std::string& custom_error_path = conf_.GetErrorPage(status);
+      std::cerr << "[DEBUG] loading custom error page for status " << status
+                << " from path: " << custom_error_path << std::endl;
+      try {  // try direct path first
+        std::string body =
+            lib::utils::ReadFileToStringOrThrow(custom_error_path);
+        res.SetBody(body);
+        return res;
+      } catch (const std::exception& e) {
+        std::cerr << "[DEBUG] failed to read error page at '"
+                  << custom_error_path << "': " << e.what() << std::endl;
+      }
+      if (!location_match_.loc || custom_error_path.empty() ||
+          custom_error_path[0] != '/') {
+        // nothing more to try
+      } else {
+        std::string alt = location_match_.loc->GetRoot();
+        if (!alt.empty() && alt[alt.size() - 1] == '/')
+          alt.resize(alt.size() - 1);
+        std::string candidate =
+            alt + custom_error_path;  // location_root + "/errors/404.html"
+        std::cerr << "[DEBUG] trying alternative error page path: '"
+                  << candidate << "'" << std::endl;
+        try {
+          std::string body = lib::utils::ReadFileToStringOrThrow(candidate);
+          res.SetBody(body);
+          return res;
+        } catch (const std::exception& e) {
+          std::cerr << "[DEBUG] failed to read alternative error page at '"
+                    << candidate << "': " << e.what() << std::endl;
+        }
+      }
+    }
+  } catch (...) {
+    // fall back to default error page
+    // if any error occurs while reading custom error page
+  }
+  res.EnsureDefaultErrorContent();
+  return res;
 }

--- a/srcs/RequestHandler.cpp
+++ b/srcs/RequestHandler.cpp
@@ -368,27 +368,24 @@ HttpResponse RequestHandler::BuildErrorResponse(lib::http::Status status) {
 
   try {
     if (conf_.HasErrorPage(status)) {
-      const std::string& custom_error_path = conf_.GetErrorPage(status);
-      std::cerr << "[DEBUG] loading custom error page for status " << status
-                << " from path: " << custom_error_path << std::endl;
-      try {  // try direct path first
-        std::string body =
-            lib::utils::ReadFileToStringOrThrow(custom_error_path);
+      lib::type::Optional<std::string> custom_error_path =
+          conf_.GetErrorPage(status);
+      if (custom_error_path.HasValue()) {
+        const std::string body =
+            lib::utils::ReadFileToStringOrThrow(custom_error_path.Value());
         res.SetBody(body);
         return res;
-      } catch (const std::exception& e) {
-        std::cerr << "[DEBUG] failed to read error page at '"
-                  << custom_error_path << "': " << e.what() << std::endl;
       }
-      if (!location_match_.loc || custom_error_path.empty() ||
-          custom_error_path[0] != '/') {
+      if (!location_match_.loc || !custom_error_path.HasValue() ||
+          custom_error_path.Value()[0] != '/') {
         // nothing more to try
       } else {
         std::string alt = location_match_.loc->GetRoot();
         if (!alt.empty() && alt[alt.size() - 1] == '/')
           alt.resize(alt.size() - 1);
         std::string candidate =
-            alt + custom_error_path;  // location_root + "/errors/404.html"
+            alt +
+            custom_error_path.Value();  // location_root + "/errors/404.html"
         std::cerr << "[DEBUG] trying alternative error page path: '"
                   << candidate << "'" << std::endl;
         try {
@@ -401,9 +398,11 @@ HttpResponse RequestHandler::BuildErrorResponse(lib::http::Status status) {
         }
       }
     }
-  } catch (...) {
+  } catch (const std::exception& e) {
     // fall back to default error page
     // if any error occurs while reading custom error page
+    std::cerr << "[DEBUG] failed to read custom error page: " << e.what()
+              << std::endl;
   }
   res.EnsureDefaultErrorContent();
   return res;

--- a/srcs/RequestHandler.cpp
+++ b/srcs/RequestHandler.cpp
@@ -371,30 +371,35 @@ HttpResponse RequestHandler::BuildErrorResponse(lib::http::Status status) {
       lib::type::Optional<std::string> custom_error_path =
           conf_.GetErrorPage(status);
       if (custom_error_path.HasValue()) {
-        const std::string body =
-            lib::utils::ReadFileToStringOrThrow(custom_error_path.Value());
-        res.SetBody(body);
-        return res;
-      }
-      if (!location_match_.loc || !custom_error_path.HasValue() ||
-          custom_error_path.Value()[0] != '/') {
-        // nothing more to try
-      } else {
-        std::string alt = location_match_.loc->GetRoot();
-        if (!alt.empty() && alt[alt.size() - 1] == '/')
-          alt.resize(alt.size() - 1);
-        std::string candidate =
-            alt +
-            custom_error_path.Value();  // location_root + "/errors/404.html"
-        std::cerr << "[DEBUG] trying alternative error page path: '"
-                  << candidate << "'" << std::endl;
+        // try configured custom error page path as is first
         try {
-          std::string body = lib::utils::ReadFileToStringOrThrow(candidate);
+          const std::string body =
+              lib::utils::ReadFileToStringOrThrow(custom_error_path.Value());
           res.SetBody(body);
           return res;
         } catch (const std::exception& e) {
-          std::cerr << "[DEBUG] failed to read alternative error page at '"
-                    << candidate << "': " << e.what() << std::endl;
+          std::cerr << "[DEBUG] failed to read custom error page at '"
+                    << custom_error_path.Value() << "': " << e.what()
+                    << std::endl;
+        }
+        // try alternative error page path
+        // if path starts with '/', treat it as relative to location root
+        if (location_match_.loc && !custom_error_path.Value().empty() &&
+            custom_error_path.Value()[0] == '/') {
+          std::string alt = location_match_.loc->GetRoot();
+          if (!alt.empty() && alt[alt.size() - 1] == '/')
+            alt.resize(alt.size() - 1);
+          std::string candidate =
+              alt +
+              custom_error_path.Value();  // location_root + "/errors/404.html"
+          try {
+            std::string body = lib::utils::ReadFileToStringOrThrow(candidate);
+            res.SetBody(body);
+            return res;
+          } catch (const std::exception& e) {
+            std::cerr << "[DEBUG] failed to read alternative error page at '"
+                      << candidate << "': " << e.what() << std::endl;
+          }
         }
       }
     }


### PR DESCRIPTION
This pull request refactors error handling in the HTTP request handling code to centralize and improve the construction of error responses, especially with regard to custom error pages. The changes include introducing a new `BuildErrorResponse` method, updating how error responses are generated throughout the code.

**Centralized error response construction:**

* Added a new `BuildErrorResponse` method to the `RequestHandler` class, which constructs error responses by checking for custom error pages, attempting to load them from configured paths, and falling back to default content if necessary. This method also adds appropriate headers such as `Content-Type` and `Connection`. (`srcs/RequestHandler.cpp`, `includes/RequestHandler.hpp`) [[1]](diffhunk://#diff-3bc5433b7b70bcf65c10d7baea6b7aabe0a8bcdf290af6d6164032f2ec81b125R67) [[2]](diffhunk://#diff-b374583dfa2641f32ada1af7d1bf668fbfc7be5066eaeb2e401e8eaa5f64fedfR363-R410)

**Refactored error handling in request processing:**

* Updated the `Run` method in `RequestHandler` to use `BuildErrorResponse` for generating responses to method-not-allowed errors, response status exceptions, and generic exceptions, ensuring consistent error handling and response formatting. (`srcs/RequestHandler.cpp`) [[1]](diffhunk://#diff-b374583dfa2641f32ada1af7d1bf668fbfc7be5066eaeb2e401e8eaa5f64fedfL36-L41) [[2]](diffhunk://#diff-b374583dfa2641f32ada1af7d1bf668fbfc7be5066eaeb2e401e8eaa5f64fedfL57-R55)

**Configuration improvements for error pages:**

* Replaced the string-dumping method `GetErrorPagesString` in `ServerConfig` with two new methods: `HasErrorPage`, which checks for the existence of a custom error page for a given status, and `GetErrorPage`, which retrieves the configured error page path or throws if not found. (`includes/ServerConfig.hpp`)