### PR TITLE
fix: Normalize URI before adding to location_match_

### DIFF
--- a/srcs/RequestHandler.cpp
+++ b/srcs/RequestHandler.cpp
@@ -66,7 +66,9 @@ ExecResult RequestHandler::Run() {
 
 void RequestHandler::PrepareRoutingContext() {
   const std::string req_uri = req_.GetUri();
-  location_match_ = conf_.FindLocationForUri(req_uri);
+  const std::string normalized_uri =
+      FileValidator::NormalizePathBySegments(req_uri);
+  location_match_ = conf_.FindLocationForUri(normalized_uri);
   filesystem_path_ = ResolveFilesystemPath();
 }
 

--- a/tests/request_handler/RequestHandler_NormalizeUri.test.cpp
+++ b/tests/request_handler/RequestHandler_NormalizeUri.test.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+
+#include "HttpRequest.hpp"
+#include "Location.hpp"
+#include "RequestHandler.hpp"
+#include "ServerConfig.hpp"
+
+class RequestHandlerNormalizeTest : public ::testing::Test {
+ protected:
+  ServerConfig config;
+
+  void SetUp() override {
+    Location location;
+    location.SetName("/");
+    location.SetRoot("/var/www/html");
+    location.SetIndexFile("index.html");
+    config.AddLocation(location);
+
+    Location dirlist;
+    dirlist.SetName("/dirlist");
+    dirlist.SetRoot("/var/www/dirlist");
+    dirlist.SetIndexFile("index.html");
+    config.AddLocation(dirlist);
+  }
+};
+
+TEST_F(RequestHandlerNormalizeTest, NormalizeUri_MultipleSlashes) {
+  HttpRequest request;
+  request.SetUri("///dirlist/");
+  RequestHandler handler(config, request);
+  handler.PrepareRoutingContext();
+  EXPECT_EQ(handler.ResolveFilesystemPath(), "/var/www/dirlist/");
+}
+
+TEST_F(RequestHandlerNormalizeTest, NormalizeUri_MultipleSlashesInMiddle) {
+  HttpRequest request;
+  request.SetUri("/a///b/c");
+  RequestHandler handler(config, request);
+  handler.PrepareRoutingContext();
+  EXPECT_EQ(handler.ResolveFilesystemPath(), "/var/www/html/a/b/c");
+}
+
+TEST_F(RequestHandlerNormalizeTest, NormalizeUri_MixedSlashesAndDots) {
+  HttpRequest request;
+  request.SetUri("/a/./b///c");
+  RequestHandler handler(config, request);
+  handler.PrepareRoutingContext();
+  EXPECT_EQ(handler.ResolveFilesystemPath(), "/var/www/html/a/b/c");
+}
+
+TEST_F(RequestHandlerNormalizeTest, NormalizeUri_LeadingTripleSlash) {
+  HttpRequest request;
+  request.SetUri("///");
+  RequestHandler handler(config, request);
+  handler.PrepareRoutingContext();
+  EXPECT_EQ(handler.ResolveFilesystemPath(), "/var/www/html/");
+}


### PR DESCRIPTION
`curl http://localhost:8080///dirlist/ -i` のように、スラッシュがたくさん入ってきた時に返す http response code

単純にスラッシュを一つになるように正規化して、200 が返る
リダイレクトはしないので、ブラウザの URL バーには `http://localhost:8080///dirlist/` とでる

`http://localhost:8080///dirlist/` -> `http://localhost:8080/dirlist/`
