### PR TITLE
fixing segmentation fault

### DIFF
--- a/demo/conf/webserv_eval.conf
+++ b/demo/conf/webserv_eval.conf
@@ -2,6 +2,7 @@ server {
   listen 127.0.0.1:8080;
   server_name demo_site;
   client_max_body_size 1048576;
+  error_page 404 /errors/404.html;
   error_page 500 /errors/500.html;
 
   location / {

--- a/demo/conf/webserv_eval.conf
+++ b/demo/conf/webserv_eval.conf
@@ -2,7 +2,6 @@ server {
   listen 127.0.0.1:8080;
   server_name demo_site;
   client_max_body_size 1048576;
-  error_page 404 /errors/404.html;
   error_page 500 /errors/500.html;
 
   location / {

--- a/demo/static_sites/demo_site/static/index.html
+++ b/demo/static_sites/demo_site/static/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Document</title>
+</head>
+<body>
+    <h1>This is a static site</h1>
+</body>
+</html>

--- a/includes/Webserv.hpp
+++ b/includes/Webserv.hpp
@@ -14,8 +14,7 @@ class Webserv {
   std::map<unsigned short, ServerConfig> port_to_server_configs_;
   lib::type::Fd epoll_fd_;
   std::map<int, ASocket*> sockets_;
-  std::vector<ASocket*>
-      pending_deletes_;  // deferred deletions to avoid use-after-free
+  std::vector<ASocket*> pending_deletes_;  // deferred deletions to avoid use-after-free
   void ClearResources();
 
   static const int kMaxEvents = 10;

--- a/includes/Webserv.hpp
+++ b/includes/Webserv.hpp
@@ -14,7 +14,8 @@ class Webserv {
   std::map<unsigned short, ServerConfig> port_to_server_configs_;
   lib::type::Fd epoll_fd_;
   std::map<int, ASocket*> sockets_;
-  std::vector<ASocket*> pending_deletes_;  // deferred deletions to avoid use-after-free
+  std::vector<ASocket*>
+      pending_deletes_;  // deferred deletions to avoid use-after-free
   void ClearResources();
 
   static const int kMaxEvents = 10;

--- a/includes/Webserv.hpp
+++ b/includes/Webserv.hpp
@@ -14,6 +14,8 @@ class Webserv {
   std::map<unsigned short, ServerConfig> port_to_server_configs_;
   lib::type::Fd epoll_fd_;
   std::map<int, ASocket*> sockets_;
+  std::vector<ASocket*>
+      pending_deletes_;  // deferred deletions to avoid use-after-free
   void ClearResources();
 
   static const int kMaxEvents = 10;

--- a/srcs/Webserv.cpp
+++ b/srcs/Webserv.cpp
@@ -113,7 +113,101 @@ void Webserv::Run() {
       sockets_.erase((*dit)->GetFd());
       delete *dit;
     }
+    int nfds =
+        epoll_wait(epoll_fd_.GetFd(), events, kMaxEvents, kEpollWaitTimeout);
+    if (nfds == -1) {
+      if (!pending_deletes_.empty()) {
+        for (std::vector<ASocket*>::iterator it = pending_deletes_.begin();
+             it != pending_deletes_.end(); ++it) {
+          delete *it;
+        }
+        pending_deletes_.clear();
+      }
+      continue;
+    }
+  }
 
+  void Webserv::InitServersFromConfigs(
+      const std::vector<ServerConfig>& configs) {
+    port_to_server_configs_.clear();
+    for (std::vector<ServerConfig>::const_iterator server = configs.begin();
+         server != configs.end(); ++server) {
+      const unsigned short& port = server->GetPort();
+      if (port_to_server_configs_.find(port) != port_to_server_configs_.end()) {
+        std::cerr << "Warning: Multiple server blocks for port " << port
+                  << ", using first one only" << std::endl;
+        continue;
+      }
+      port_to_server_configs_[port] = *server;
+    }
+  }
+
+  const std::map<unsigned short, ServerConfig>& Webserv::GetPortConfigs()
+      const {
+    return port_to_server_configs_;
+  }
+
+  const ServerConfig* Webserv::FindServerConfigByPort(
+      const unsigned short& port) const {
+    std::map<unsigned short, ServerConfig>::const_iterator it =
+        port_to_server_configs_.find(port);
+    if (it != port_to_server_configs_.end()) {
+      return &it->second;
+    }
+    return NULL;
+  }
+
+  void Webserv::CheckTimeout() {
+    time_t now = std::time(NULL);
+    time_t threshold = now - kRequestTimeout;
+
+    for (std::map<int, ASocket*>::iterator it = sockets_.begin();
+         it != sockets_.end();) {
+      if (it->second->IsTimeout(threshold)) {
+        ASocket* socket = it->second;
+        int fd = socket->GetFd();
+        bool should_delete = socket->HandleTimeout(epoll_fd_.GetFd());
+        if (should_delete) {
+          // remove fd(s) from epoll so epoll won't return events for them
+          // anymore
+          if (epoll_ctl(epoll_fd_.GetFd(), EPOLL_CTL_DEL, fd, NULL) == -1) {
+            std::cerr << "epoll_ctl() failed to remove timed out socket. "
+                      << strerror(errno) << std::endl;
+          }
+          int write_fd = socket->GetWriteFd();
+          if (write_fd != -1) {
+            if (epoll_ctl(epoll_fd_.GetFd(), EPOLL_CTL_DEL, write_fd, NULL) ==
+                -1) {
+              std::cerr << "epoll_ctl() failed to remove timed out socket's "
+                           "write fd. "
+                        << strerror(errno) << std::endl;
+            }
+          }
+          // delete socket;
+          sockets_.erase(it++);
+          pending_deletes_.push_back(
+              socket);  // defer deletion to avoid use-after-free
+        } else {
+          ++it;
+        }
+        std::cerr << "Connection timed out. fd: " << fd << std::endl;
+      } else {
+        ++it;
+      }
+    }
+  }
+
+  void Webserv::ClearResources() {
+    for (std::map<int, ASocket*>::iterator it = sockets_.begin();
+         it != sockets_.end(); ++it) {
+      std::cerr << "Cleaning up socket fd: " << it->second->GetFd()
+                << std::endl;
+      delete it->second;
+    }
+    std::cerr << "All sockets cleaned up." << std::endl;
+    sockets_.clear();
+
+    // ensure any deferred deletes are also freed to avoid memory leaks
     if (!pending_deletes_.empty()) {
       for (std::vector<ASocket*>::iterator it = pending_deletes_.begin();
            it != pending_deletes_.end(); ++it) {
@@ -122,81 +216,3 @@ void Webserv::Run() {
       pending_deletes_.clear();
     }
   }
-}
-
-void Webserv::InitServersFromConfigs(const std::vector<ServerConfig>& configs) {
-  port_to_server_configs_.clear();
-  for (std::vector<ServerConfig>::const_iterator server = configs.begin();
-       server != configs.end(); ++server) {
-    const unsigned short& port = server->GetPort();
-    if (port_to_server_configs_.find(port) != port_to_server_configs_.end()) {
-      std::cerr << "Warning: Multiple server blocks for port " << port
-                << ", using first one only" << std::endl;
-      continue;
-    }
-    port_to_server_configs_[port] = *server;
-  }
-}
-
-const std::map<unsigned short, ServerConfig>& Webserv::GetPortConfigs() const {
-  return port_to_server_configs_;
-}
-
-const ServerConfig* Webserv::FindServerConfigByPort(
-    const unsigned short& port) const {
-  std::map<unsigned short, ServerConfig>::const_iterator it =
-      port_to_server_configs_.find(port);
-  if (it != port_to_server_configs_.end()) {
-    return &it->second;
-  }
-  return NULL;
-}
-
-void Webserv::CheckTimeout() {
-  time_t now = std::time(NULL);
-  time_t threshold = now - kRequestTimeout;
-
-  for (std::map<int, ASocket*>::iterator it = sockets_.begin();
-       it != sockets_.end();) {
-    if (it->second->IsTimeout(threshold)) {
-      ASocket* socket = it->second;
-      int fd = socket->GetFd();
-      bool should_delete = socket->HandleTimeout(epoll_fd_.GetFd());
-      if (should_delete) {
-        // remove fd(s) from epoll so epoll won't return events for them anymore
-        if (epoll_ctl(epoll_fd_.GetFd(), EPOLL_CTL_DEL, fd, NULL) == -1) {
-          std::cerr << "epoll_ctl() failed to remove timed out socket. "
-                    << strerror(errno) << std::endl;
-        }
-        int write_fd = socket->GetWriteFd();
-        if (write_fd != -1) {
-          if (epoll_ctl(epoll_fd_.GetFd(), EPOLL_CTL_DEL, write_fd, NULL) ==
-              -1) {
-            std::cerr
-                << "epoll_ctl() failed to remove timed out socket's write fd. "
-                << strerror(errno) << std::endl;
-          }
-        }
-        // delete socket;
-        sockets_.erase(it++);
-        pending_deletes_.push_back(
-            socket);  // defer deletion to avoid use-after-free
-      } else {
-        ++it;
-      }
-      std::cerr << "Connection timed out. fd: " << fd << std::endl;
-    } else {
-      ++it;
-    }
-  }
-}
-
-void Webserv::ClearResources() {
-  for (std::map<int, ASocket*>::iterator it = sockets_.begin();
-       it != sockets_.end(); ++it) {
-    std::cerr << "Cleaning up socket fd: " << it->second->GetFd() << std::endl;
-    delete it->second;
-  }
-  std::cerr << "All sockets cleaned up." << std::endl;
-  sockets_.clear();
-}

--- a/srcs/Webserv.cpp
+++ b/srcs/Webserv.cpp
@@ -63,7 +63,7 @@ Webserv::Webserv(const std::string& config_file) {
 void Webserv::Run() {
   epoll_event events[kMaxEvents];
   while (true) {
-    CheckTimeout(); // timed out sockets will be registered for deletion
+    CheckTimeout();  // timed out sockets will be registered for deletion
     int nfds =
         epoll_wait(epoll_fd_.GetFd(), events, kMaxEvents, kEpollWaitTimeout);
     if (nfds == -1) {
@@ -105,8 +105,10 @@ void Webserv::Run() {
                           &write_ev) == -1) {
               std::cerr << "epoll_ctl() failed for write fd. "
                         << strerror(errno) << std::endl;
-              epoll_ctl(epoll_fd_.GetFd(), EPOLL_CTL_DEL, result.new_socket->GetFd(),
-                        NULL);  // remove the new socket since we failed to add its write fd
+              epoll_ctl(epoll_fd_.GetFd(), EPOLL_CTL_DEL,
+                        result.new_socket->GetFd(),
+                        NULL);  // remove the new socket since we failed to add
+                                // its write fd
               sockets_.erase(result.new_socket->GetFd());
               delete result.new_socket;
             }
@@ -131,92 +133,89 @@ void Webserv::Run() {
   }
 }
 
-  void Webserv::InitServersFromConfigs(
-      const std::vector<ServerConfig>& configs) {
-    port_to_server_configs_.clear();
-    for (std::vector<ServerConfig>::const_iterator server = configs.begin();
-         server != configs.end(); ++server) {
-      const unsigned short& port = server->GetPort();
-      if (port_to_server_configs_.find(port) != port_to_server_configs_.end()) {
-        std::cerr << "Warning: Multiple server blocks for port " << port
-                  << ", using first one only" << std::endl;
-        continue;
-      }
-      port_to_server_configs_[port] = *server;
+void Webserv::InitServersFromConfigs(const std::vector<ServerConfig>& configs) {
+  port_to_server_configs_.clear();
+  for (std::vector<ServerConfig>::const_iterator server = configs.begin();
+       server != configs.end(); ++server) {
+    const unsigned short& port = server->GetPort();
+    if (port_to_server_configs_.find(port) != port_to_server_configs_.end()) {
+      std::cerr << "Warning: Multiple server blocks for port " << port
+                << ", using first one only" << std::endl;
+      continue;
     }
+    port_to_server_configs_[port] = *server;
   }
+}
 
-  const std::map<unsigned short, ServerConfig>& Webserv::GetPortConfigs()
-      const {
-    return port_to_server_configs_;
+const std::map<unsigned short, ServerConfig>& Webserv::GetPortConfigs() const {
+  return port_to_server_configs_;
+}
+
+const ServerConfig* Webserv::FindServerConfigByPort(
+    const unsigned short& port) const {
+  std::map<unsigned short, ServerConfig>::const_iterator it =
+      port_to_server_configs_.find(port);
+  if (it != port_to_server_configs_.end()) {
+    return &it->second;
   }
+  return NULL;
+}
 
-  const ServerConfig* Webserv::FindServerConfigByPort(
-      const unsigned short& port) const {
-    std::map<unsigned short, ServerConfig>::const_iterator it =
-        port_to_server_configs_.find(port);
-    if (it != port_to_server_configs_.end()) {
-      return &it->second;
-    }
-    return NULL;
-  }
+void Webserv::CheckTimeout() {
+  time_t now = std::time(NULL);
+  time_t threshold = now - kRequestTimeout;
 
-  void Webserv::CheckTimeout() {
-    time_t now = std::time(NULL);
-    time_t threshold = now - kRequestTimeout;
-
-    for (std::map<int, ASocket*>::iterator it = sockets_.begin();
-         it != sockets_.end();) {
-      if (it->second->IsTimeout(threshold)) {
-        ASocket* socket = it->second;
-        int fd = socket->GetFd();
-        bool should_delete = socket->HandleTimeout(epoll_fd_.GetFd());
-        if (should_delete) {
-          // remove fd(s) from epoll so epoll won't return events for them
-          // anymore
-          if (epoll_ctl(epoll_fd_.GetFd(), EPOLL_CTL_DEL, fd, NULL) == -1) {
-            std::cerr << "epoll_ctl() failed to remove timed out socket. "
+  for (std::map<int, ASocket*>::iterator it = sockets_.begin();
+       it != sockets_.end();) {
+    if (it->second->IsTimeout(threshold)) {
+      ASocket* socket = it->second;
+      int fd = socket->GetFd();
+      bool should_delete = socket->HandleTimeout(epoll_fd_.GetFd());
+      if (should_delete) {
+        // remove fd(s) from epoll so epoll won't return events for them
+        // anymore
+        if (epoll_ctl(epoll_fd_.GetFd(), EPOLL_CTL_DEL, fd, NULL) == -1) {
+          std::cerr << "epoll_ctl() failed to remove timed out socket. "
+                    << strerror(errno) << std::endl;
+        }
+        int write_fd = socket->GetWriteFd();
+        if (write_fd != -1) {
+          if (epoll_ctl(epoll_fd_.GetFd(), EPOLL_CTL_DEL, write_fd, NULL) ==
+              -1) {
+            std::cerr << "epoll_ctl() failed to remove timed out socket's "
+                         "write fd. "
                       << strerror(errno) << std::endl;
           }
-          int write_fd = socket->GetWriteFd();
-          if (write_fd != -1) {
-            if (epoll_ctl(epoll_fd_.GetFd(), EPOLL_CTL_DEL, write_fd, NULL) ==
-                -1) {
-              std::cerr << "epoll_ctl() failed to remove timed out socket's "
-                           "write fd. "
-                        << strerror(errno) << std::endl;
-            }
-          }
-          // delete socket;
-          sockets_.erase(it++);
-          pending_deletes_.push_back(
-              socket);  // defer deletion to avoid use-after-free
-        } else {
-          ++it;
         }
-        std::cerr << "Connection timed out. fd: " << fd << std::endl;
+        // delete socket;
+        sockets_.erase(it++);
+        pending_deletes_.push_back(
+            socket);  // defer deletion to avoid use-after-free
       } else {
         ++it;
       }
+      std::cerr << "Connection timed out. fd: " << fd << std::endl;
+    } else {
+      ++it;
     }
   }
+}
 
-  void Webserv::ClearResources() {
-    for (std::map<int, ASocket*>::iterator it = sockets_.begin();
-         it != sockets_.end(); ++it) {
-      std::cerr << "Cleaning up socket fd: " << it->second->GetFd()
-                << std::endl;
-      delete it->second;
-    }
-    std::cerr << "All sockets cleaned up." << std::endl;
-    sockets_.clear();
-
-    // ensure any deferred deletes are also freed to avoid memory leaks
-    if (!pending_deletes_.empty()) {
-      for (std::vector<ASocket*>::iterator it = pending_deletes_.begin();
-           it != pending_deletes_.end(); ++it) {
-        delete *it;
-      }
-      pending_deletes_.clear();
-    }
+void Webserv::ClearResources() {
+  for (std::map<int, ASocket*>::iterator it = sockets_.begin();
+       it != sockets_.end(); ++it) {
+    std::cerr << "Cleaning up socket fd: " << it->second->GetFd() << std::endl;
+    delete it->second;
   }
+  std::cerr << "All sockets cleaned up." << std::endl;
+  sockets_.clear();
+
+  // ensure any deferred deletes are also freed to avoid memory leaks
+  if (!pending_deletes_.empty()) {
+    for (std::vector<ASocket*>::iterator it = pending_deletes_.begin();
+         it != pending_deletes_.end(); ++it) {
+      delete *it;
+    }
+    pending_deletes_.clear();
+  }
+}

--- a/srcs/Webserv.cpp
+++ b/srcs/Webserv.cpp
@@ -187,7 +187,6 @@ void Webserv::CheckTimeout() {
                       << strerror(errno) << std::endl;
           }
         }
-        // delete socket;
         sockets_.erase(it++);
         pending_deletes_.push_back(
             socket);  // defer deletion to avoid use-after-free

--- a/srcs/Webserv.cpp
+++ b/srcs/Webserv.cpp
@@ -63,11 +63,16 @@ Webserv::Webserv(const std::string& config_file) {
 void Webserv::Run() {
   epoll_event events[kMaxEvents];
   while (true) {
-    CheckTimeout();
+    CheckTimeout(); // timed out sockets will be registered for deletion
     int nfds =
         epoll_wait(epoll_fd_.GetFd(), events, kMaxEvents, kEpollWaitTimeout);
     if (nfds == -1) {
       std::cerr << "epoll_wait() failed. " << strerror(errno) << std::endl;
+      for (std::vector<ASocket*>::iterator it = pending_deletes_.begin();
+           it != pending_deletes_.end(); ++it) {
+        delete *it;
+      }
+      pending_deletes_.clear();
       continue;
     }
 
@@ -89,6 +94,7 @@ void Webserv::Run() {
                     << std::endl;
           sockets_.erase(result.new_socket->GetFd());
           delete result.new_socket;
+          result.new_socket = NULL;
         } else {
           int write_fd = result.new_socket->GetWriteFd();
           if (write_fd != -1) {
@@ -99,6 +105,10 @@ void Webserv::Run() {
                           &write_ev) == -1) {
               std::cerr << "epoll_ctl() failed for write fd. "
                         << strerror(errno) << std::endl;
+              epoll_ctl(epoll_fd_.GetFd(), EPOLL_CTL_DEL, result.new_socket->GetFd(),
+                        NULL);  // remove the new socket since we failed to add its write fd
+              sockets_.erase(result.new_socket->GetFd());
+              delete result.new_socket;
             }
           }
         }
@@ -113,19 +123,13 @@ void Webserv::Run() {
       sockets_.erase((*dit)->GetFd());
       delete *dit;
     }
-    int nfds =
-        epoll_wait(epoll_fd_.GetFd(), events, kMaxEvents, kEpollWaitTimeout);
-    if (nfds == -1) {
-      if (!pending_deletes_.empty()) {
-        for (std::vector<ASocket*>::iterator it = pending_deletes_.begin();
-             it != pending_deletes_.end(); ++it) {
-          delete *it;
-        }
-        pending_deletes_.clear();
-      }
-      continue;
+    for (std::vector<ASocket*>::iterator it = pending_deletes_.begin();
+         it != pending_deletes_.end(); ++it) {
+      delete *it;
     }
+    pending_deletes_.clear();
   }
+}
 
   void Webserv::InitServersFromConfigs(
       const std::vector<ServerConfig>& configs) {

--- a/srcs/Webserv.cpp
+++ b/srcs/Webserv.cpp
@@ -113,6 +113,14 @@ void Webserv::Run() {
       sockets_.erase((*dit)->GetFd());
       delete *dit;
     }
+
+    if (!pending_deletes_.empty()) {
+      for (std::vector<ASocket*>::iterator it = pending_deletes_.begin();
+           it != pending_deletes_.end(); ++it) {
+        delete *it;
+      }
+      pending_deletes_.clear();
+    }
   }
 }
 
@@ -155,8 +163,24 @@ void Webserv::CheckTimeout() {
       int fd = socket->GetFd();
       bool should_delete = socket->HandleTimeout(epoll_fd_.GetFd());
       if (should_delete) {
-        delete socket;
+        // remove fd(s) from epoll so epoll won't return events for them anymore
+        if (epoll_ctl(epoll_fd_.GetFd(), EPOLL_CTL_DEL, fd, NULL) == -1) {
+          std::cerr << "epoll_ctl() failed to remove timed out socket. "
+                    << strerror(errno) << std::endl;
+        }
+        int write_fd = socket->GetWriteFd();
+        if (write_fd != -1) {
+          if (epoll_ctl(epoll_fd_.GetFd(), EPOLL_CTL_DEL, write_fd, NULL) ==
+              -1) {
+            std::cerr
+                << "epoll_ctl() failed to remove timed out socket's write fd. "
+                << strerror(errno) << std::endl;
+          }
+        }
+        // delete socket;
         sockets_.erase(it++);
+        pending_deletes_.push_back(
+            socket);  // defer deletion to avoid use-after-free
       } else {
         ++it;
       }


### PR DESCRIPTION
This pull request introduces improvements to the socket resource management in the web server to prevent use-after-free errors, and adds a new static site. The main focus is on deferring socket deletions safely and ensuring proper epoll cleanup. Additionally, a minor configuration change and a new static HTML page are included.

**Resource management and safety improvements:**

* Added a `pending_deletes_` vector to the `Webserv` class to defer deletion of sockets, preventing use-after-free issues during iteration. Sockets marked for deletion are now deleted after the main event loop iteration. (`includes/Webserv.hpp`, `srcs/Webserv.cpp`) [[1]](diffhunk://#diff-24ce5dc1361cda63adb1ab688c76260d885c3672e486f64e8768d563dce90f6bR17-R18) [[2]](diffhunk://#diff-a6180a1a1cb6037657a8b56b4980db518bfb60f7bf11be1f1ed2c5fabd17c90eR116-R123)
* Updated the `CheckTimeout` method to remove file descriptors from epoll before deleting sockets, and to defer socket deletion by adding them to `pending_deletes_` instead of deleting immediately. (`srcs/Webserv.cpp`)

**Static site addition:**

* Added a new `index.html` file for the static site at `demo/static_sites/demo_site/static/index.html`.

**Configuration update:**

* Removed the custom 404 error page directive from the web server configuration file `demo/conf/webserv_eval.conf`.